### PR TITLE
Add release workflow for building and publishing Docker images to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,8 +55,8 @@ jobs:
             # Static development tag
             type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref_name == 'development' }}
           
-            # Unique SHA tag for dev builds (recommended)
-            type=sha,prefix=dev-,enable=${{ github.event_name == 'push' && github.ref_name == 'development' }}
+            # Unique SHA tag for dev builds
+            type=sha,prefix=development-,enable=${{ github.event_name == 'push' && github.ref_name == 'development' }}
           
             # Manual Test Tags (manual trigger)
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
You need to give the workflow write permissions in the Actions settings:
https://github.com/jaboll-ai/Uraniarr/settings/actions

<img width="826" height="224" alt="image" src="https://github.com/user-attachments/assets/8d8b086a-5157-48d4-99dd-adc8c8f764a6" />

Once that’s enabled, creating a release with a tag like `v1.0.0` will automatically trigger the workflow, which will build the image and push it to GitHub Packages.

For testing, you can also manually trigger an on-demand release here:
https://github.com/jaboll-ai/Uraniarr/actions/workflows/release.yaml
<img width="351" height="259" alt="image" src="https://github.com/user-attachments/assets/0cb11680-018c-4b65-a31e-ca572cf3d5df" />
