### PR TITLE
Normalize release tag in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,19 @@ jobs:
         id: repo_name_lowercase
         run: echo "REPO_NAME_LOWERCASE=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
+      - name: Normalize Release Tag (Handle v.X.Y.Z and vX.Y.Z)
+        if: github.event_name == 'release'
+        id: clean_tag
+        run: |
+          # The GITHUB_REF for a release is typically refs/tags/v.0.0.1 or refs/tags/v0.0.1
+          # This command strips "refs/tags/" and then removes any leading 'v' or '.'
+          RAW_TAG=${{ github.ref_name }}
+          # Use 'sed' to remove leading 'v' and any '.' immediately following it.
+          CLEANED_TAG=$(echo "$RAW_TAG" | sed -E 's/^[vV]\.?//')
+          echo "RAW_TAG: $RAW_TAG"
+          echo "CLEANED_TAG: $CLEANED_TAG"
+          echo "CLEAN_TAG=$CLEANED_TAG" >> $GITHUB_ENV
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -47,9 +60,10 @@ jobs:
           images: ghcr.io/${{ env.REPO_NAME_LOWERCASE }}
           tags: |
             # Main/Production Tags (on 'release')
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}},enable=${{ github.event_name == 'release' }}
+            # Use the cleaned version for SemVer extraction.
+            type=semver,pattern={{version}},value=${{ env.CLEAN_TAG }},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.CLEAN_TAG }},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}},value=${{ env.CLEAN_TAG }},enable=${{ github.event_name == 'release' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
           
             # Static development tag


### PR DESCRIPTION
Added a step to normalize the release tag by removing leading 'v' and '.' characters.

Because i saw that your action had an warning and the version is missing on GH Release. 
https://github.com/jaboll-ai/Uraniarr/actions/runs/19505236280/job/55829541224#step:7:54